### PR TITLE
Add possibility of choosing an instance of a service using CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Adjust permissions for gh actions
 - Implementation of Redmine issue client interface
+- Add config parser from toml files
+- Add plugin based instance manager
+- Make use of instance manager in auth-verify command
+- Extend instance manager with possibility to initialize issue client
+- Adapt copy command to work with any configured project
 
 ## [0.0.2] - 2024-04-01
 ### Added

--- a/README.md
+++ b/README.md
@@ -42,35 +42,43 @@ The basic functionality of `issx` is provided through the `issx` command-line in
 
 Currently, there is only one command available: `copy`.
 
-It allows to copy issues from one place to another.
-As for now, it supports copying issues between **projects in the same backend** (Gitlab).
+It allows to copy issues from one [configured](#configuration-file) project to another .
 
 ```shell
-issx copy --source-project-id=<id> --target-project-id=<id> <issue-id>
+issx copy --source=<project_name> --target=<project_name> <issue-id>
 ```
 
-where `source-project-id` and `target-project-id` are the IDs of the projects in the same backend and
-`issue-id` is the ID of the issue to be copied.
+where `source` and `target` are the names of the projects configured in the configuration file.
+
+### Configuration file
+
+The configuration file can be either in the working directory (`issx.toml`) or in `~/.config/issx.toml`.
+
+It should have the following structure:
+
+```toml
+[instances.INSTANCE_NAME]
+    backend = "gitlab" / "redmine"
+    url = "<absolute url to the instance>"
+    token = "<API token used for authentication>"
+
+[projects.PROJECT_NAME]
+    instance = "INSTANCE_NAME"
+    project = "<project_id>"
+```
+
+`Instances` section is used to configure the instances of the services (e.g. Gitlab, Redmine)
+that `issx` will interact with.
+
+`Projects` section is used to configure the projects that `issx` will work with. Each project should be associated with
+an instance.
+`project` field should contain the project id available in the chosen instance (usually it is a number).
 
 ### Authentication
 
-#### Gitlab
-For the Gitlab backend we use the `python-gitlab` package with file-based [configuration](https://python-gitlab.readthedocs.io/en/stable/cli-usage.html#configuration-file-format).
-`issx` will use the configured default section from the configuration file located in `~/.python-gitlab.cfg`
-(`private_instance` in the example below).
-
-```
-[global]
-default = private_instance
-
-[private_instance]
-url = https://private-gitlab.com/
-private_token = <your_private_token>
-```
-
-To validate the authentication, you can use command:
+To validate the authentication with a newly configured instance, you can use command `issx auth-verify`:
 ```shell
-issx auth-verify
+issx auth-verify --instance=<instance_name>
 ```
 
 ## Development

--- a/src/issx/cli.py
+++ b/src/issx/cli.py
@@ -6,15 +6,20 @@ from gitlab import Gitlab
 from rich.console import Console
 
 from issx.clients import SupportedBackend
-from issx.clients.gitlab import GitlabClient
+from issx.clients.gitlab import GitlabClient, GitlabInstanceClient
+from issx.clients.redmine import RedmineInstanceClient
+from issx.instance_managers import GenericConfigParser, InstanceManager
 from issx.services import CopyIssueService
 
 app = typer.Typer(no_args_is_help=True)
 
 BackendOption = Annotated[SupportedBackend, typer.Option()]
-
+InstanceNameOption = Annotated[str, typer.Option("--instance")]
 
 console = Console()
+
+InstanceManager.register_backend(SupportedBackend.gitlab, GitlabInstanceClient)
+InstanceManager.register_backend(SupportedBackend.redmine, RedmineInstanceClient)
 
 
 @app.command()
@@ -40,24 +45,31 @@ def copy(
 
 
 @app.command()
-def auth_verify(backend_name: BackendOption = SupportedBackend.gitlab) -> None:
+def auth_verify(instance_name: InstanceNameOption) -> None:
+    config = GenericConfigParser()
+    instance_manager = InstanceManager(config)
     try:
-        gl = Gitlab.from_config()
+        instance = instance_manager.get_instance_client(instance_name)
     except Exception as e:
-        console.print(f"Error when reading config file.\n" f"Details: {e}", style="red")
+        console.print_exception()
+        console.print("Error when configuring client instance.\n", style="red")
         raise typer.Exit(1) from e
     try:
-        gl.auth()
+        username = asyncio.run(instance.auth())
+        if not username:
+            raise Exception("Authentication failed")
     except Exception as e:
+        console.print_exception()
         console.print(
-            f"Error when authenticating to {gl.url}.\nDetails: {e}", style="red"
+            f"Error when authenticating to {instance.get_instance_url()}",
+            style="red",
         )
         raise typer.Exit(1) from e
     else:
         console.print(
             "Authentication successful",
-            f"Instance: {gl.url}",
-            f"User: {gl.user and gl.user.username}",
+            f"Instance: {instance.get_instance_url()}",
+            f"User: {username}",
             sep="\n",
             style="green bold italic",
         )

--- a/src/issx/cli.py
+++ b/src/issx/cli.py
@@ -2,8 +2,8 @@ import asyncio
 from typing import Annotated
 
 import typer
-from gitlab import Gitlab
 from rich.console import Console
+from rich.text import Text
 
 from issx.clients import SupportedBackend
 from issx.clients.gitlab import GitlabClient, GitlabInstanceClient
@@ -15,7 +15,9 @@ app = typer.Typer(no_args_is_help=True)
 
 BackendOption = Annotated[SupportedBackend, typer.Option()]
 InstanceNameOption = Annotated[str, typer.Option("--instance")]
-
+ProjectOption = Annotated[
+    str, typer.Option("--project", help="Project name configured in the config file")
+]
 console = Console()
 
 InstanceManager.register_backend(
@@ -28,23 +30,41 @@ InstanceManager.register_backend(
 
 @app.command()
 def copy(
-    source_project_id: Annotated[int, typer.Option()],
-    target_project_id: Annotated[int, typer.Option()],
+    source_project_name: Annotated[
+        str,
+        typer.Option(
+            "--source", help="Source project name configured in the config file"
+        ),
+    ],
+    target_project_name: Annotated[
+        str,
+        typer.Option(
+            "--target", help="Target project name configured in the config file"
+        ),
+    ],
     issue_id: int,
-    source_backend_name: BackendOption = SupportedBackend.gitlab,
-    target_backend_name: BackendOption = SupportedBackend.gitlab,
 ) -> int:
-    typer.echo(
-        f"Copying issue {issue_id} from project {source_project_id}"
-        f" to project {target_project_id}"
+    console.print(
+        Text.assemble(
+            f"Copying issue {issue_id} from project ",
+            (source_project_name, "bold magenta"),
+            " to project ",
+            (target_project_name, "bold magenta"),
+        )
     )
-    gl = Gitlab.from_config()
-    source_client = GitlabClient(gl, source_project_id)
-    target_client = GitlabClient(gl, target_project_id)
+    config = GenericConfigParser()
+    instance_manager = InstanceManager(config)
+    try:
+        source_client = instance_manager.get_project_client(source_project_name)
+        target_client = instance_manager.get_project_client(target_project_name)
+    except Exception as e:
+        console.print_exception()
+        console.print("Error when configuring client instance.\n", style="red")
+        raise typer.Exit(1) from e
     new_issue = asyncio.run(
         CopyIssueService(source_client, target_client).copy(issue_id)
     )
-    typer.echo(f"New issue created: {new_issue}")
+    console.print(f"Success!\n{new_issue}", style="green")
     return 0
 
 

--- a/src/issx/cli.py
+++ b/src/issx/cli.py
@@ -7,7 +7,7 @@ from rich.console import Console
 
 from issx.clients import SupportedBackend
 from issx.clients.gitlab import GitlabClient, GitlabInstanceClient
-from issx.clients.redmine import RedmineInstanceClient
+from issx.clients.redmine import RedmineClient, RedmineInstanceClient
 from issx.instance_managers import GenericConfigParser, InstanceManager
 from issx.services import CopyIssueService
 
@@ -18,8 +18,12 @@ InstanceNameOption = Annotated[str, typer.Option("--instance")]
 
 console = Console()
 
-InstanceManager.register_backend(SupportedBackend.gitlab, GitlabInstanceClient)
-InstanceManager.register_backend(SupportedBackend.redmine, RedmineInstanceClient)
+InstanceManager.register_backend(
+    SupportedBackend.gitlab, GitlabInstanceClient, GitlabClient
+)
+InstanceManager.register_backend(
+    SupportedBackend.redmine, RedmineInstanceClient, RedmineClient
+)
 
 
 @app.command()

--- a/src/issx/clients/__init__.py
+++ b/src/issx/clients/__init__.py
@@ -7,3 +7,4 @@ from issx.clients.gitlab import GitlabClient
 
 class SupportedBackend(StrEnum):
     gitlab = "gitlab"
+    redmine = "redmine"

--- a/src/issx/clients/gitlab.py
+++ b/src/issx/clients/gitlab.py
@@ -78,3 +78,10 @@ class GitlabClient(IssueClientInterface, GitlabInstanceClient):
             raise IssueDoesNotExistError(
                 f"Issue with id={issue_id} does not exist"
             ) from e
+
+    @classmethod
+    def from_config(cls, config: dict) -> Self:
+        return cls(
+            GitlabInstanceClient.from_config(config["instance"]).client,
+            project_id=int(config["project"]),
+        )

--- a/src/issx/clients/gitlab.py
+++ b/src/issx/clients/gitlab.py
@@ -1,10 +1,10 @@
-from typing import cast
+from typing import Self, cast
 
 from gitlab import Gitlab, GitlabGetError
 from gitlab.v4.objects import Project, ProjectIssue
 
 from issx.clients.exceptions import IssueDoesNotExistError, ProjectDoesNotExistError
-from issx.clients.interfaces import IssueClientInterface
+from issx.clients.interfaces import InstanceClientInterface, IssueClientInterface
 from issx.domain.issues import Issue
 
 
@@ -24,11 +24,29 @@ class IssueMapper:
         )
 
 
-class GitlabClient(IssueClientInterface):
-    def __init__(self, client: Gitlab, project_id: int):
+class GitlabInstanceClient(InstanceClientInterface):
+    @classmethod
+    def from_config(cls, config: dict) -> Self:
+        return cls(Gitlab(config["url"], private_token=config["token"]))
+
+    def __init__(self, client: Gitlab):
         self.client = client
+
+    async def auth(self) -> str | None:
+        self.client.auth()
+        if user := self.client.user:
+            return cast(str, user.username)
+        return None
+
+    def get_instance_url(self) -> str:
+        return self.client.url
+
+
+class GitlabClient(IssueClientInterface, GitlabInstanceClient):
+    def __init__(self, client: Gitlab, project_id: int):
         self.project_id = project_id
         self._project: Project | None = None
+        super().__init__(client)
 
     async def create_issue(self, title: str, description: str) -> Issue:
         project = await self._get_project()

--- a/src/issx/clients/interfaces.py
+++ b/src/issx/clients/interfaces.py
@@ -45,3 +45,8 @@ class IssueClientInterface(abc.ABC):
     @abc.abstractmethod
     async def create_issue(self, title: str, description: str) -> Issue:
         pass
+
+    @classmethod
+    @abc.abstractmethod
+    def from_config(cls, config: dict) -> Self:
+        pass

--- a/src/issx/clients/interfaces.py
+++ b/src/issx/clients/interfaces.py
@@ -1,6 +1,40 @@
 import abc
+from typing import Self
 
 from issx.domain.issues import Issue
+
+
+class InstanceClientInterface(abc.ABC):
+    """
+    Interface for a client that interacts with an issue tracker instance
+    """
+
+    @abc.abstractmethod
+    async def auth(self) -> str | None:
+        """
+        Authenticate the client with the instance.
+        Raises an internal error if the authentication fails or returns None.
+        :return: The username of the authenticated user or None
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_instance_url(self) -> str:
+        """
+        :return: The URL of the instance
+        """
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def from_config(cls, config: dict) -> Self:
+        """
+        Create an instance of the client from a configuration dictionary.
+        :param config: The configuration dictionary. Higher level code should validate
+        the configuration.
+        :return: An instance of the client
+        """
+        pass
 
 
 class IssueClientInterface(abc.ABC):

--- a/src/issx/clients/redmine.py
+++ b/src/issx/clients/redmine.py
@@ -78,3 +78,10 @@ class RedmineClient(IssueClientInterface, RedmineInstanceClient):
                     f"Project with id={self._project_id} does not exist"
                 ) from e
         return self._project
+
+    @classmethod
+    def from_config(cls, config: dict) -> Self:
+        return cls(
+            RedmineInstanceClient.from_config(config["instance"]).client,
+            project_id=int(config["project"]),
+        )

--- a/src/issx/instance_managers.py
+++ b/src/issx/instance_managers.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from typing import Any
+
+import tomllib
+
+
+class GenericConfigParser:
+    def __init__(self, config_file: Path | None = None):
+        self.config_file = config_file or self._find_config_file()
+        self._data: dict[str, dict[str, dict]] = tomllib.loads(
+            self.config_file.read_text()
+        )
+
+    def get_instance_config(self, instance: str) -> dict:
+        return self._data["instances"][instance]
+
+    def __getitem__(self, item: str) -> Any:
+        return self._data[item]
+
+    @staticmethod
+    def _find_config_file() -> Path:
+        locations = [
+            Path("issx.toml"),
+            Path("~/.config/issx.toml").expanduser(),
+        ]
+        for location in locations:
+            if location.exists() and location.is_file() and location.suffix == ".toml":
+                return location
+        raise FileNotFoundError("No configuration file found")


### PR DESCRIPTION
- Add config parser from toml files
- Add plugin-based instance manager
- Make use of the instance manager in the auth-verify command
- Extend instance manager with the possibility to initialize issue client
- Adapt the copy command to work with any configured project

## Description

In order to select one of the configured instances via CLI it was necessary to:
* Add support for config file
* Add instance manager responsible for dynamic creation of client instances
* Extend CLI

## Checklist

- [ ] ~Tests covering the new functionality have been added~
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
