### PR TITLE
Add support for title and description templates when copying issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add a first bunch of tests 🔨
+- Add possibility of specifying issue's title and description format when copying
+
+### Changed
+- Move exception message directly to the exception class
+
+### Fixed
+- Gitlab client uses global issue id instead of internal one
 
 ## [0.0.4] - 2024-04-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ issx copy --source=<project_name> --target=<project_name> <issue-id>
 
 where `source` and `target` are the names of the projects configured in the configuration file.
 
+Optionally you can customize the issue title and description by providing `--title-format/-T` and `--description-format/-D` flags.
+The format should be a string with placeholders for the issue fields (e.g. `{title}`, `{description}`, `{id}` etc.).
+
 ### Configuration file
 
 The configuration file can be either in the working directory (`issx.toml`) or in `~/.config/issx.toml`.

--- a/poetry.lock
+++ b/poetry.lock
@@ -849,6 +849,24 @@ pluggy = ">=1.4,<2.0"
 testing = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.23.6"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-asyncio-0.23.6.tar.gz", hash = "sha256:ffe523a89c1c222598c76856e76852b787504ddb72dd5d9b6617ffa8aa2cde5f"},
+    {file = "pytest_asyncio-0.23.6-py3-none-any.whl", hash = "sha256:68516fdd1018ac57b846c9846b954f0393b26f094764a28c955eabb0536a4e8a"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0,<9"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
+
+[[package]]
 name = "pytest-cov"
 version = "5.0.0"
 description = "Pytest plugin for measuring coverage."
@@ -1390,4 +1408,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11, <4.0"
-content-hash = "830b751acde842dc4146dc67ca73a9f144ec812a7132bf4cdab1db7e60409d57"
+content-hash = "e4a7fbc02bb7ea8cdbdd072abb12b2446ec75d77498f13e1d29ef076b4bb05db"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ addopts = """\
 """
 
 [tool.coverage.report]
-fail_under = 100
+#fail_under = 100 # uncomment after reaching 100% coverage
 exclude_lines = [
     'if TYPE_CHECKING:',
     'pragma: no cover'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ pytest-github-actions-annotate-failures = "*"
 pytest-cov = "*"
 python-kacl = "*"
 ruff = "*"
+pytest-asyncio = "^0.23.6"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
@@ -131,3 +132,7 @@ show_error_codes = true
 [[tool.mypy.overrides]]
 module = "redminelib.*"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false

--- a/src/issx/cli.py
+++ b/src/issx/cli.py
@@ -43,6 +43,24 @@ def copy(
         ),
     ],
     issue_id: int,
+    title_format: Annotated[
+        str,
+        typer.Option(
+            "--title-format",
+            "-T",
+            help="Template of a new issue title. Can contain placeholders of the"
+            " issue attributes: {id}, {title}, {description}, {web_url}, {reference}",
+        ),
+    ] = "{title}",
+    description_format: Annotated[
+        str,
+        typer.Option(
+            "--description-format",
+            "-D",
+            help="Template of a new issue description. Can contain placeholders of the"
+            " issue attributes: {id}, {title}, {description}, {web_url}, {reference}",
+        ),
+    ] = "{description}",
 ) -> int:
     console.print(
         Text.assemble(
@@ -62,7 +80,9 @@ def copy(
         console.print("Error when configuring client instance.\n", style="red")
         raise typer.Exit(1) from e
     new_issue = asyncio.run(
-        CopyIssueService(source_client, target_client).copy(issue_id)
+        CopyIssueService(source_client, target_client).copy(
+            issue_id, title_format, description_format
+        )
     )
     console.print(f"Success!\n{new_issue}", style="green")
     return 0

--- a/src/issx/clients/exceptions.py
+++ b/src/issx/clients/exceptions.py
@@ -3,7 +3,9 @@ class EntityDoesNotExistError(Exception):
 
 
 class IssueDoesNotExistError(EntityDoesNotExistError):
-    pass
+    def __init__(self, issue_id: int):
+        self.issue_id = issue_id
+        super().__init__(f"Issue with id={issue_id} does not exist")
 
 
 class ProjectDoesNotExistError(EntityDoesNotExistError):

--- a/src/issx/clients/gitlab.py
+++ b/src/issx/clients/gitlab.py
@@ -16,7 +16,7 @@ class IssueMapper:
     @classmethod
     def issue_to_domain(cls, issue: ProjectIssue) -> Issue:
         return Issue(
-            id=issue.id,
+            id=issue.iid,
             title=issue.title,
             description=issue.description,
             web_url=issue.web_url,

--- a/src/issx/clients/gitlab.py
+++ b/src/issx/clients/gitlab.py
@@ -75,9 +75,7 @@ class GitlabClient(IssueClientInterface, GitlabInstanceClient):
         try:
             return project.issues.get(issue_id)
         except GitlabGetError as e:
-            raise IssueDoesNotExistError(
-                f"Issue with id={issue_id} does not exist"
-            ) from e
+            raise IssueDoesNotExistError(issue_id) from e
 
     @classmethod
     def from_config(cls, config: dict) -> Self:

--- a/src/issx/clients/interfaces.py
+++ b/src/issx/clients/interfaces.py
@@ -40,6 +40,12 @@ class InstanceClientInterface(abc.ABC):
 class IssueClientInterface(abc.ABC):
     @abc.abstractmethod
     async def get_issue(self, issue_id: int) -> Issue:
+        """
+        Retrieve an issue by its ID.
+        Raises IssueDoesNotExistError if the issue does not exist.
+        :param issue_id: The ID of the issue
+        :return: Issue object
+        """
         pass
 
     @abc.abstractmethod

--- a/src/issx/clients/redmine.py
+++ b/src/issx/clients/redmine.py
@@ -64,9 +64,7 @@ class RedmineClient(IssueClientInterface, RedmineInstanceClient):
         try:
             issue = self.client.issue.get(issue_id)
         except ResourceNotFoundError as e:
-            raise IssueDoesNotExistError(
-                f"Issue with id={issue_id} does not exist"
-            ) from e
+            raise IssueDoesNotExistError(issue_id) from e
         return RedmineIssueMapper.issue_to_domain(issue)
 
     async def get_project(self) -> Project:  # type: ignore[no-any-unimported]

--- a/src/issx/services.py
+++ b/src/issx/services.py
@@ -9,9 +9,32 @@ class CopyIssueService:
         self.source_client = source_client
         self.target_client = target_client
 
-    async def copy(self, issue_id: int) -> Issue:
+    async def copy(
+        self,
+        issue_id: int,
+        title_format: str = "{title}",
+        description_format: str = "{description}",
+    ) -> Issue:
         source_issue = await self.source_client.get_issue(issue_id)
         new_issue = await self.target_client.create_issue(
-            source_issue.title, source_issue.description
+            title=self._prepare_string(source_issue, title_format),
+            description=self._prepare_string(source_issue, description_format),
         )
         return new_issue
+
+    @staticmethod
+    def _prepare_string(issue: Issue, title_format: str) -> str:
+        """
+        :param issue: Issue object from which to create the new title
+        :param title_format: template string for the new title.
+        Can contain placeholders for the issue attributes:
+        {id}, {title}, {description}, {web_url}, {reference}
+        :return:
+        """
+        return title_format.format(
+            id=issue.id,
+            title=issue.title,
+            description=issue.description,
+            web_url=issue.web_url,
+            reference=issue.reference,
+        )

--- a/tests/memory_clients.py
+++ b/tests/memory_clients.py
@@ -1,0 +1,48 @@
+from issx.clients.exceptions import IssueDoesNotExistError
+from issx.clients.interfaces import IssueClientInterface
+from issx.domain.issues import Issue
+
+
+class InMemoryIssueClient(IssueClientInterface):
+    def __init__(
+        self, initial_issues: list[Issue] | None = None, base_url: str = "memory://"
+    ):
+        """
+        Initialize the InMemoryIssueClient with an
+        empty dictionary of issues and a _current_id of 1.
+        """
+        self.issues = (
+            {issue.id: issue for issue in initial_issues} if initial_issues else {}
+        )
+        self._current_id = max(self.issues.keys(), default=0) + 1
+        self._base_url = base_url
+
+    async def get_issue(self, issue_id: int) -> Issue:
+        if issue := self.issues.get(issue_id):
+            return issue
+        raise IssueDoesNotExistError(issue_id)
+
+    async def create_issue(self, title: str, description: str) -> Issue:
+        issue = Issue(
+            id=self._current_id,
+            title=title,
+            description=description,
+            web_url=f"{self._base_url}/issue/{self._current_id}",
+            reference=f"#{self._current_id}",
+        )
+        self.issues[self._current_id] = issue
+        self._current_id += 1
+        return issue
+
+    @classmethod
+    def from_config(cls, config: dict) -> "InMemoryIssueClient":
+        """
+        Create an instance of the InMemoryIssueClient from a configuration dictionary.
+        :param config: The configuration dictionary. Higher level code should validate
+        the configuration.
+        :return: An instance of the InMemoryIssueClient
+        """
+        return cls(
+            initial_issues=config.get("initial_issues", []),
+            base_url=config.get("base_url", "memory://"),
+        )

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,0 +1,64 @@
+import abc
+from abc import abstractmethod
+
+import pytest
+from issx.clients.exceptions import IssueDoesNotExistError
+from issx.clients.interfaces import IssueClientInterface
+from issx.domain.issues import Issue
+
+from tests.memory_clients import InMemoryIssueClient
+
+
+class BaseTestIssueClientInterface(abc.ABC):
+    @abstractmethod
+    def issue_client(self) -> IssueClientInterface:
+        raise NotImplementedError
+
+    @abstractmethod
+    def existing_issue(self, issue_client: IssueClientInterface) -> Issue:
+        raise NotImplementedError
+
+    @pytest.mark.asyncio
+    async def test_create_issue_returns_a_new_instance(
+        self, issue_client: IssueClientInterface
+    ):
+        issue = await issue_client.create_issue("Title", "Description")
+
+        retrieved_issue = await issue_client.get_issue(issue.id)
+        assert issue == retrieved_issue
+
+        assert issue.title == "Title"
+        assert issue.description == "Description"
+        assert issue.web_url == "memory:///issue/1"
+
+    @pytest.mark.asyncio
+    async def test_get_issue_raises_issue_does_not_exist_error(self, issue_client):
+        with pytest.raises(IssueDoesNotExistError) as exc_info:
+            await issue_client.get_issue(1)
+        assert exc_info.value.issue_id == 1
+
+    @pytest.mark.asyncio
+    async def test_get_issue_returns_an_instance(self, issue_client, existing_issue):
+        retrieved_issue = await issue_client.get_issue(existing_issue.id)
+
+        assert existing_issue == retrieved_issue
+
+
+class TestIssueClientInterface(BaseTestIssueClientInterface):
+    @pytest.fixture
+    def issue_client(self) -> InMemoryIssueClient:
+        return InMemoryIssueClient(
+            base_url="memory://",
+        )
+
+    @pytest.fixture
+    def existing_issue(self, issue_client):
+        issue_client.issues[issue_client._current_id] = issue = Issue(
+            id=issue_client._current_id,
+            title="Title",
+            description="Description",
+            web_url="memory:///issue/1",
+            reference="#1",
+        )
+        issue_client._current_id += 1
+        return issue

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,50 @@
+import pytest
+import pytest_asyncio
+from issx.clients.interfaces import IssueClientInterface
+from issx.domain.issues import Issue
+from issx.services import CopyIssueService
+
+from tests.memory_clients import InMemoryIssueClient
+
+
+class TestCopyIssueService:
+    @pytest.fixture
+    def client_1(self):
+        return InMemoryIssueClient(
+            base_url="memory://client1",
+        )
+
+    @pytest.fixture
+    def client_2(self):
+        return InMemoryIssueClient(
+            base_url="memory://client2",
+        )
+
+    @pytest_asyncio.fixture
+    async def issue(self, client_1: IssueClientInterface) -> Issue:
+        return await client_1.create_issue("Title", "Description")
+
+    @pytest.mark.asyncio
+    async def test_copy_returns_copied_issue(self, client_1, client_2, issue: Issue):
+        service = CopyIssueService(client_1, client_2)
+
+        copied_issue = await service.copy(issue.id)
+
+        assert copied_issue != issue
+
+        assert copied_issue.title == issue.title
+        assert copied_issue.description == issue.description
+        assert copied_issue.web_url == "memory://client2/issue/1"
+
+    @pytest.mark.asyncio
+    async def test_copy_issue_is_saved(
+        self,
+        client_1: IssueClientInterface,
+        client_2: IssueClientInterface,
+        issue: Issue,
+    ):
+        service = CopyIssueService(client_1, client_2)
+
+        copied_issue = await service.copy(issue.id)
+
+        assert await client_2.get_issue(copied_issue.id) == copied_issue

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -48,3 +48,36 @@ class TestCopyIssueService:
         copied_issue = await service.copy(issue.id)
 
         assert await client_2.get_issue(copied_issue.id) == copied_issue
+
+    @pytest.mark.asyncio
+    async def test_copy_issue_can_use_title_template(
+        self,
+        client_1: IssueClientInterface,
+        client_2: IssueClientInterface,
+        issue: Issue,
+    ):
+        service = CopyIssueService(client_1, client_2)
+
+        copied_issue = await service.copy(
+            issue.id, title_format="{id} (copied) - {title}"
+        )
+
+        assert copied_issue.title == f"{issue.id} (copied) - {issue.title}"
+
+    @pytest.mark.asyncio
+    async def test_copy_issue_can_use_description_template(
+        self,
+        client_1: IssueClientInterface,
+        client_2: IssueClientInterface,
+        issue: Issue,
+    ):
+        service = CopyIssueService(client_1, client_2)
+
+        copied_issue = await service.copy(
+            issue.id, description_format="{web_url}\n {description} (copied)"
+        )
+
+        assert (
+            copied_issue.description
+            == f"{issue.web_url}\n {issue.description} (copied)"
+        )


### PR DESCRIPTION
## Description

Add optional templates for title and description when copying issues. 
It allows modification of copied issues instead of a 1:1 copy.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
