### PR TITLE
Add possibility to allow for duplicate issues when copying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 - Add method for finding issues by a title to the client interface
+- Possibility to allow for duplicate issues when copying (based on title)
 
 ## [0.1.0] - 2024-04-14
 ### Added

--- a/src/issx/cli.py
+++ b/src/issx/cli.py
@@ -61,6 +61,16 @@ def copy(
             " issue attributes: {id}, {title}, {description}, {web_url}, {reference}",
         ),
     ] = "{description}",
+    allow_duplicates: Annotated[
+        bool,
+        typer.Option(
+            "--allow-duplicates",
+            "-A",
+            help="Allow for duplicate issues. If set, the command will return the first"
+            " issue found with the same title. If no issues are found,"
+            " a new issue will be created.",
+        ),
+    ] = False,
 ) -> int:
     console.print(
         Text.assemble(
@@ -81,7 +91,10 @@ def copy(
         raise typer.Exit(1) from e
     new_issue = asyncio.run(
         CopyIssueService(source_client, target_client).copy(
-            issue_id, title_format, description_format
+            issue_id,
+            title_format,
+            description_format,
+            allow_duplicates=allow_duplicates,
         )
     )
     console.print(f"Success!\n{new_issue}", style="green")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -81,3 +81,36 @@ class TestCopyIssueService:
             copied_issue.description
             == f"{issue.web_url}\n {issue.description} (copied)"
         )
+
+    @pytest.mark.asyncio
+    async def test_copy_issue_does_not_create_duplicate(
+        self, client_1, client_2, issue: Issue
+    ):
+        title_format = "{id} - {title}"
+        service = CopyIssueService(client_1, client_2)
+
+        copied_issue_1 = await service.copy(
+            issue.id, title_format=title_format, allow_duplicates=False
+        )
+        copied_issue_2 = await service.copy(
+            issue.id, title_format=title_format, allow_duplicates=False
+        )
+
+        assert copied_issue_1.title == f"{issue.id} - {issue.title}"
+        assert copied_issue_2 == copied_issue_1
+
+    @pytest.mark.asyncio
+    async def test_copy_issue_creates_duplicate(self, client_1, client_2, issue: Issue):
+        title_format = "{id} - {title}"
+        service = CopyIssueService(client_1, client_2)
+
+        copied_issue_1 = await service.copy(
+            issue.id, title_format=title_format, allow_duplicates=True
+        )
+        copied_issue_2 = await service.copy(
+            issue.id, title_format=title_format, allow_duplicates=True
+        )
+
+        assert copied_issue_1.title == f"{issue.id} - {issue.title}"
+        assert copied_issue_2.title == f"{issue.id} - {issue.title}"
+        assert copied_issue_2 != copied_issue_1


### PR DESCRIPTION
## Description

Extend the `copy` command with the possibility of allowing for duplicated issues. 
Before copying, the application checks whether an issue with the same title (considering a title format) exists in the target client. If any is found, then the first is returned. Otherwise, it copies the source issue to the target service. 

`-A` flag disables the behavior of checking for existing issues.

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
