### PR TITLE
Allow specifying config class per client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ## Added
 - Add tests for instance manager
+- Add possibility to specify a config class per instance client
 
 ## [0.4.0] - 2024-04-21
 ### Added

--- a/src/issx/clients/gitlab.py
+++ b/src/issx/clients/gitlab.py
@@ -1,5 +1,6 @@
 from typing import Self, cast
 
+from attr import asdict
 from gitlab import Gitlab, GitlabGetError
 from gitlab.v4.objects import CurrentUser, Project, ProjectIssue
 
@@ -30,10 +31,6 @@ class IssueMapper:
 
 
 class GitlabInstanceClient(InstanceClientInterface):
-    @classmethod
-    def instance_from_config(cls, instance_config: InstanceConfig) -> Self:
-        return cls(Gitlab(instance_config.url, private_token=instance_config.token))
-
     def __init__(self, client: Gitlab):
         self.client = client
 
@@ -51,6 +48,11 @@ class GitlabInstanceClient(InstanceClientInterface):
 
     def get_instance_url(self) -> str:
         return self.client.url
+
+    @classmethod
+    def instance_from_config(cls, instance_config: InstanceConfig) -> Self:
+        instance_config = cls.instance_config_class(**asdict(instance_config))
+        return cls(Gitlab(instance_config.url, private_token=instance_config.token))
 
 
 class GitlabClient(IssueClientInterface, GitlabInstanceClient):
@@ -107,6 +109,7 @@ class GitlabClient(IssueClientInterface, GitlabInstanceClient):
     def from_config(
         cls, instance_config: InstanceConfig, project_config: ProjectFlatConfig
     ) -> Self:
+        project_config = cls.project_config_class(**asdict(project_config))
         return cls(
             GitlabInstanceClient.instance_from_config(instance_config).client,
             project_id=int(project_config.project),

--- a/src/issx/clients/interfaces.py
+++ b/src/issx/clients/interfaces.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Self
+from typing import ClassVar, Self
 
 from issx.domain.config import InstanceConfig, ProjectFlatConfig
 from issx.domain.issues import Issue
@@ -9,6 +9,8 @@ class InstanceClientInterface(abc.ABC):
     """
     Interface for a client that interacts with an issue tracker instance
     """
+
+    instance_config_class: ClassVar[type[InstanceConfig]] = InstanceConfig
 
     @abc.abstractmethod
     async def auth(self) -> str | None:
@@ -31,6 +33,9 @@ class InstanceClientInterface(abc.ABC):
     def instance_from_config(cls, instance_config: InstanceConfig) -> Self:
         """
         Create an instance of the client from a configuration dictionary.
+        If required, the instance_config can be converted to an instance-specific
+        configuration according to the `instance_config_class` attribute of the client.
+
         :param instance_config: The configuration object. Higher level code
         should validate the configuration.
         :return: An instance of the client
@@ -39,6 +44,8 @@ class InstanceClientInterface(abc.ABC):
 
 
 class IssueClientInterface(abc.ABC):
+    project_config_class: ClassVar[type[ProjectFlatConfig]] = ProjectFlatConfig
+
     @abc.abstractmethod
     async def get_issue(self, issue_id: int) -> Issue:
         """
@@ -78,9 +85,14 @@ class IssueClientInterface(abc.ABC):
     ) -> Self:
         """
         Create an instance of the client from configuration classes.
+        If required, the project_config can be converted to a project-specific
+        configuration according to the `project_config_class` attribute of the client.
+
         Args:
             instance_config: InstanceConfig to configure the client to the instance
-            project_config: ProjectFlatConfig to configure client
+            project_config: ProjectFlatConfig to configure client. This config can then
+            be converted to a project-specific config according to
+            the `project_config_class` attribute of the client.
             to the particular project
 
         Returns:

--- a/src/issx/clients/redmine.py
+++ b/src/issx/clients/redmine.py
@@ -1,5 +1,6 @@
 from typing import Self
 
+from attr import asdict
 from redminelib import Redmine
 from redminelib.exceptions import ResourceNotFoundError
 from redminelib.resources import Issue as RedmineIssue
@@ -44,6 +45,7 @@ class RedmineInstanceClient(InstanceClientInterface):
 
     @classmethod
     def instance_from_config(cls, instance_config: InstanceConfig) -> Self:
+        instance_config = cls.instance_config_class(**asdict(instance_config))
         return cls(
             Redmine(
                 instance_config.url,
@@ -99,6 +101,7 @@ class RedmineClient(IssueClientInterface, RedmineInstanceClient):
     def from_config(
         cls, instance_config: InstanceConfig, project_config: ProjectFlatConfig
     ) -> Self:
+        project_config = cls.project_config_class(**asdict(project_config))
         return cls(
             RedmineInstanceClient.instance_from_config(instance_config).client,
             project_id=int(project_config.project),

--- a/src/issx/domain/config.py
+++ b/src/issx/domain/config.py
@@ -6,7 +6,9 @@ from issx.domain import SupportedBackend
 
 @define
 class InstanceConfig:
-    backend: SupportedBackend = attr.ib(validator=attr.validators.in_(SupportedBackend))
+    backend: SupportedBackend = attr.ib(
+        validator=attr.validators.in_(SupportedBackend.__members__.values())
+    )
     url: str = attr.ib(validator=attr.validators.instance_of(str))
     token: str = attr.ib(validator=attr.validators.instance_of(str))
     raw_config: dict = attr.ib(

--- a/src/issx/domain/config.py
+++ b/src/issx/domain/config.py
@@ -9,9 +9,15 @@ class InstanceConfig:
     backend: SupportedBackend = attr.ib(validator=attr.validators.in_(SupportedBackend))
     url: str = attr.ib(validator=attr.validators.instance_of(str))
     token: str = attr.ib(validator=attr.validators.instance_of(str))
+    raw_config: dict = attr.ib(
+        validator=attr.validators.instance_of(dict), factory=dict
+    )
 
 
 @define
 class ProjectFlatConfig:
     instance: str = attr.ib(validator=attr.validators.instance_of(str))
     project: str = attr.ib(validator=attr.validators.instance_of(str))
+    raw_config: dict = attr.ib(
+        validator=attr.validators.instance_of(dict), factory=dict
+    )

--- a/src/issx/instance_managers/config_parser.py
+++ b/src/issx/instance_managers/config_parser.py
@@ -46,6 +46,7 @@ class GenericConfigParser:
                     backend=SupportedBackend(instance.get("backend")),
                     url=instance.get("url"),
                     token=instance.get("token"),
+                    raw_config=instance,
                 )
                 for name, instance in data["instances"].items()
             },
@@ -53,6 +54,7 @@ class GenericConfigParser:
                 name: ProjectFlatConfig(
                     instance=project.get("instance"),
                     project=project.get("project"),
+                    raw_config=project,
                 )
                 for name, project in data.get("projects", {}).items()
             },

--- a/src/issx/instance_managers/managers.py
+++ b/src/issx/instance_managers/managers.py
@@ -26,12 +26,44 @@ class InstanceManager:
         cls.backends.clear()
 
     def get_instance_client(self, instance: str) -> InstanceClientInterface:
+        """
+        Get an instance client for a given instance name.
+
+        Converts the instance config to the appropriate config class
+         and creates an instance client.
+        Args:
+            instance: Instance name
+
+        Returns: Instance of an instance client
+        """
         instance_config = self.config.get_instance_config(instance)
         client_class = self.backends[instance_config.backend][0]
+        instance_config = client_class.instance_config_class(
+            **instance_config.raw_config, raw_config=instance_config.raw_config
+        )
         return client_class.instance_from_config(instance_config)
 
     def get_project_client(self, project: str) -> IssueClientInterface:
+        """
+        Get a project client for a given project name.
+
+        Converts the project config to the appropriate config class
+        and creates a project client.
+        Args:
+            project: Project name
+
+        Returns: Instance of a project client
+
+        """
         project_config = self.config.get_project_config(project)
         instance_config = self.config.get_instance_config(project_config.instance)
-        client_class = self.backends[instance_config.backend][1]
-        return client_class.from_config(instance_config, project_config)
+        instance_client_class, project_client_class = self.backends[
+            instance_config.backend
+        ]
+        instance_config = instance_client_class.instance_config_class(
+            **instance_config.raw_config, raw_config=instance_config.raw_config
+        )
+        project_config = project_client_class.project_config_class(
+            **project_config.raw_config, raw_config=project_config.raw_config
+        )
+        return project_client_class.from_config(instance_config, project_config)

--- a/tests/memory_clients.py
+++ b/tests/memory_clients.py
@@ -6,7 +6,11 @@ from issx.domain.issues import Issue
 
 class InMemoryIssueClient(IssueClientInterface):
     def __init__(
-        self, initial_issues: list[Issue] | None = None, base_url: str = "memory://"
+        self,
+        initial_issues: list[Issue] | None = None,
+        base_url: str = "memory://",
+        instance_config: InstanceConfig | None = None,
+        project_config: ProjectFlatConfig | None = None,
     ):
         """
         Initialize the InMemoryIssueClient with an
@@ -17,6 +21,8 @@ class InMemoryIssueClient(IssueClientInterface):
         )
         self._current_id = max(self.issues.keys(), default=0) + 1
         self._base_url = base_url
+        self.instance_config = instance_config
+        self.project_config = project_config
 
     async def get_issue(self, issue_id: int) -> Issue:
         if issue := self.issues.get(issue_id):
@@ -47,4 +53,5 @@ class InMemoryIssueClient(IssueClientInterface):
         """
         Create an instance of the client from a configuration classes
         """
-        return cls()
+        project_config = cls.project_config_class(**(project_config.raw_config))
+        return cls(instance_config=instance_config, project_config=project_config)


### PR DESCRIPTION
## Description

This feature allows specifying config class per client class. It makes possible to validate config against backend-specific configuration options.

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the change is too minor to be documented
- [x] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
